### PR TITLE
Update FasMCP server, added HTTP transport.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,79 @@ pip install -r requirements.txt
 
 ## Claude Desktop integration
 
-```bash
-mcp install server.py
+Claude Desktop should launch the server via STDIO. Do not use “mcp install” or “mcp run” with this server.
 
-# Custom name
-mcp install server.py --name "FIWARE MCP Server"
+Example configuration (adjust paths for your environment):
+```json
+{
+  "mcpServers": {
+    "CB-assistant": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--with",
+        "requests>=2.31.0",
+        "--with",
+        "fastmcp>=0.3.0",
+        "python",
+        "PATH\\TO\\FIWARE-MCP-Server\\server.py"
+      ]
+    }
+  }
+}
+```
 
-# Environment variables, if any
-mcp install server.py -v API_KEY=abc123 -v DB_URL=postgres://...
-mcp install server.py -f .env
+Alternative if dependencies are installed with pip:
+```json
+{
+  "mcpServers": {
+    "CB-assistant": {
+      "command": "python",
+      "args": [
+        "PATH\\TO\\FIWARE-MCP-Server\\server.py"
+      ]
+    }
+  }
+}
 ```
 
 ## Usage
 
-Start the MCP server:
+By default, running the script starts the server in STDIO mode. Use `--http` to start an HTTP server.
+
+- STDIO (default):
 ```bash
 python server.py
-# or
-mcp run server.py
 ```
 
-The server will start on `127.0.0.1:5001` by default.
+- HTTP mode:
+```bash
+python server.py --http
+```
+
+- HTTP host/port (optional):
+```bash
+python server.py --http --host 127.0.0.1 --port 5001
+```
+
+When running with `--http`, the server binds to the provided host/port and uses stateless HTTP sessions for compatibility with streamable HTTP clients.
+
+### Redirecting with ngrok (HTTP mode)
+
+To use LLMs via external APIs (for example the OpenAI Responses API) you may need to expose your local MCP server to the Internet. Use ngrok to create a public HTTPS tunnel to the server when running in HTTP mode.
+
+1. Sign up at https://ngrok.com and install the ngrok client for your OS.
+2. Add your ngrok auth token to the client (follow ngrok's OS-specific setup). For example:
+   - ngrok (v3) config command: ngrok config add-authtoken <YOUR_AUTH_TOKEN>
+3. Start your MCP server in HTTP mode (if not already running). Example:
+   - python server.py --http --host 127.0.0.1 --port 5001
+4. Start an ngrok tunnel that forwards to your HTTP server:
+   - ngrok http http://127.0.0.1:5001
+   (replace host/port if you configured them differently)
+5. Once ngrok is running it will display one or more public forwarding URLs. The MCP endpoint will be reachable at:
+   - {PUBLIC_URL}/mcp
+
+Note: Keep your auth token secure. The public URL stays active while ngrok is running and will cease to be reachable when you stop the tunnel.
 
 ### Available Tools
 
@@ -105,8 +157,8 @@ result = publish_to_CB(entity_data=entity_data)
 ## Configuration
 
 The server can be configured by modifying the following parameters in `server.py`:
-- Host address
-- Port number
+- Host address (HTTP mode only)
+- Port number (HTTP mode only)
 - Timeout settings
 
 ## Error Handling
@@ -123,4 +175,4 @@ Feel free to submit issues and enhancement requests!
 
 ## License
 
-This project is licensed under the Apache License 2.0. 
+This project is licensed under the Apache License 2.0.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests>=2.31.0
-fastmcp>=0.1.0
+fastmcp>=0.3.0
 uv>=0.4.18
 mcp[cli]

--- a/server.py
+++ b/server.py
@@ -26,6 +26,7 @@ signal.signal(signal.SIGINT, signal_handler)
 # This MCP server provides tools for interacting with a FIWARE Context Broker
 mcp = FastMCP(
     name="CB-assistant",
+    stateless_http=True, #fixing closed sessions when using streamable-http
 )
 
 # This tool gets the Context Broker version
@@ -208,15 +209,14 @@ def publish_to_CB(address: str="localhost", port: int=1026, entity_data: dict=No
 if __name__ == "__main__":
     try:
         print("Starting MCP server 'CB-assistant' on 0.0.0.0:5001")
-        print(f"Full URL: http://127.0.0.1:5001/sse")
+        print(f"Full URL: http://0.0.0.0:5001") 
       
         mcp.run(
-            transport="sse",
-            host="127.0.0.1",
+            transport="http",
+            host="0.0.0.0",       
             port=5001,
         )
 
     except Exception as e:
         print(f"Error: {e}")
-        # Sleep before exiting to give time for error logs
-        time.sleep(3) 
+        time.sleep(3)

--- a/server.py
+++ b/server.py
@@ -1,4 +1,4 @@
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 import time
 import signal
 import sys
@@ -26,8 +26,6 @@ signal.signal(signal.SIGINT, signal_handler)
 # This MCP server provides tools for interacting with a FIWARE Context Broker
 mcp = FastMCP(
     name="CB-assistant",
-    host="127.0.0.1",
-    port=5001
 )
 
 # This tool gets the Context Broker version
@@ -209,10 +207,16 @@ def publish_to_CB(address: str="localhost", port: int=1026, entity_data: dict=No
 
 if __name__ == "__main__":
     try:
-        print("Starting MCP server 'CB-assistant' on 127.0.0.1:5001")
-        # Use this approach to keep the server running
-        mcp.run()
+        print("Starting MCP server 'CB-assistant' on 0.0.0.0:5001")
+        print(f"Full URL: http://127.0.0.1:5001/sse")
+      
+        mcp.run(
+            transport="sse",
+            host="127.0.0.1",
+            port=5001,
+        )
+
     except Exception as e:
         print(f"Error: {e}")
         # Sleep before exiting to give time for error logs
-        time.sleep(3)
+        time.sleep(3) 

--- a/server.py
+++ b/server.py
@@ -5,6 +5,7 @@ import sys
 import requests
 import json
 import logging
+import argparse
 
 # --- Logging to STDERR only ---
 logger = logging.getLogger("cb-assistant")
@@ -16,9 +17,19 @@ logger.addHandler(_stderr_handler)
 logger.propagate = False
 
 
+# Parse CLI args early so we can configure MCP instance accordingly
+_parser = argparse.ArgumentParser(add_help=False)
+_parser.add_argument("--http", action="store_true", help="Run MCP server over HTTP transport")
+_parser.add_argument("--host", default="127.0.0.1", help="HTTP host (only for --http)")
+_parser.add_argument("--port", type=int, default=5001, help="HTTP port (only for --http)")
+_args, _ = _parser.parse_known_args()
+_IS_HTTP = _args.http
+_HOST = _args.host
+_PORT = _args.port
+
 # Handle SIGINT (Ctrl+C) gracefully
 def signal_handler(sig, frame):
-    print("Shutting down server gracefully...")
+    logger.info("Shutting down server gracefully...")  # was print
     sys.exit(0)
 
 signal.signal(signal.SIGINT, signal_handler)
@@ -26,7 +37,7 @@ signal.signal(signal.SIGINT, signal_handler)
 # This MCP server provides tools for interacting with a FIWARE Context Broker
 mcp = FastMCP(
     name="CB-assistant",
-    stateless_http=True, #fixing closed sessions when using streamable-http
+    stateless_http=_IS_HTTP,  # only enable when running in HTTP mode
 )
 
 # This tool gets the Context Broker version
@@ -169,9 +180,9 @@ def execute_query(params: str) -> str:
 
 # This tool creates or updates entities in the Context Broker
 @mcp.tool()
-def publish_to_CB(address: str="localhost", port: int=1026, entity_data: dict=None) -> str:
+def publish_to_CB(address: str="localhost", port: int=1026, entity_data: dict=None) -> str:  # type: ignore
     """Publish an entity to the CB."""
-    broker_url = f"http://{address}:{port}/ngsi-ld/v1/entities"  # Default URL, adjust if needed
+    broker_url = f"http://{address}:{port}/ngsi-ld/v1/entities"
     headers = {
         "Content-Type": "application/ld+json"
     }
@@ -179,9 +190,9 @@ def publish_to_CB(address: str="localhost", port: int=1026, entity_data: dict=No
         response = requests.post(broker_url, json=entity_data, headers=headers)
 
         if response.status_code == 201:
-            print(f"Success! Entity created. Status code: {response.status_code}")
+            logger.info("Success! Entity created. Status code: %s", response.status_code)
         elif response.status_code == 409:
-            print(f"Entity already exists. Status code: {response.status_code}")
+            logger.info("Entity already exists. Status code: %s", response.status_code)
 
             # Update the entity if it already exists
             entity_id = entity_data["id"]
@@ -194,29 +205,32 @@ def publish_to_CB(address: str="localhost", port: int=1026, entity_data: dict=No
             update_data.pop("@context", None)
 
             update_response = requests.patch(update_url, json=update_data, headers=headers)
-            print(f"Update attempt result: {update_response.status_code}")
+            logger.info("Update attempt result: %s", update_response.status_code)
         else:
-            print(f"Error creating entity. Status code: {response.status_code}")
-            print(f"Response content: {response.text}")
+            logger.error("Error creating entity. Status code: %s", response.status_code)
+            logger.error("Response content: %s", response.text)
     except Exception as e:
-        print(f"An error occurred: {e}")
+        logger.exception("An error occurred: %s", e)
 
-    print("\nEntity data sent:")
-    print(json.dumps(entity_data, indent=2))
+    logger.info("Entity data sent: %s", json.dumps(entity_data, indent=2))
     return json.dumps({"status": "completed"})
 
 
 if __name__ == "__main__":
     try:
-        print("Starting MCP server 'CB-assistant' on 0.0.0.0:5001")
-        print(f"Full URL: http://0.0.0.0:5001") 
-      
-        mcp.run(
-            transport="http",
-            host="0.0.0.0",       
-            port=5001,
-        )
+        if _IS_HTTP:
+            logger.info("Starting MCP server 'CB-assistant' on %s:%s (HTTP)", _HOST, _PORT)
+            mcp.run(
+                transport="http",
+                host=_HOST,
+                port=_PORT,
+            )
+        else:
+            logger.info("Starting MCP server 'CB-assistant' (STDIO)")
+            mcp.run(
+                transport="stdio",
+            )
 
     except Exception as e:
-        print(f"Error: {e}")
+        logger.exception("Error: %s", e)
         time.sleep(3)


### PR DESCRIPTION
Changes made:
- Updated FastMCP version. That requires to configure Claude Desktop differently (see Readme.md). Cannot use mcp install server.py anymore with this version.
- Added http transport (run with arg --http) and instructions on how to expose the server via ngrok. See Readme.md.
- Updated Readme.md